### PR TITLE
feat: add combat stats and equipment system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# CodexAI
+# CodexAI Idle Game Prototype
+
+Ceci est une base de jeu **idle** inspirée de *Legend of Mushrooms*.
+Votre personnage combat automatiquement un ennemi à la fois.
+Les images des ennemis changent selon leur niveau (`enemy1.1.png`, `enemy1.2.png`...).
+Par défaut, chaque niveau comporte 10 ennemis avec des PV augmentant de 10 à chaque étape.
+Le menu "Personnage" sert de page d'équipement avec un emplacement d'arme
+équipé d'une épée infligeant 2 dégâts par seconde.
+
+## Démarrage
+Ouvrez simplement `index.html` dans votre navigateur.
+
+Les images PNG du héros, de l'arme et des ennemis se trouvent dans le dossier `assets/`.
+Pour ajouter de nouveaux monstres, placez un fichier nommé `enemyX.Y.png`
+(`X` = monde, `Y` = sous-niveau) et ajustez la constante `ENEMIES_PER_STAGE`
+dans `main.js` si vous souhaitez un autre nombre d'ennemis par niveau.
+
+## Développement
+Aucun outil de build n'est nécessaire pour cette démo.
+
+## Tests
+Pour l'instant il n'y a pas de tests, la commande suivante affiche un message :
+```bash
+npm test
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <title>Idle Mushrooms Prototype</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="ui">
+    <button id="characterBtn">Personnage</button>
+    <div id="heroHp">HP: 100</div>
+    <div id="killCount">Enemies defeated: 0</div>
+  </div>
+  <div id="game">
+    <img id="hero" alt="Hero" />
+  </div>
+  <div id="characterMenu" class="hidden">
+    <h2>Équipement</h2>
+    <div class="slot">
+      <span>Arme&nbsp;:</span>
+      <img id="weaponSlot" alt="Arme équipée" />
+    </div>
+    <button id="closeCharacter">Fermer</button>
+  </div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,104 @@
+// Paths to images. Replace the files in the assets folder to customize.
+const heroImage = 'assets/hero.png';
+const swordImage = 'assets/sword.png';
+
+const hero = document.getElementById('hero');
+hero.src = heroImage;
+const gameArea = document.getElementById('game');
+
+// Hero stats and equipment
+const heroStats = { hp: 100, baseAttack: 0, attack: 0 };
+const weapon = { attack: 2, img: swordImage };
+heroStats.attack = heroStats.baseAttack + weapon.attack;
+document.getElementById('weaponSlot').src = weapon.img;
+
+let killCount = 0;
+const killDisplay = document.getElementById('killCount');
+const heroHpDisplay = document.getElementById('heroHp');
+function updateDisplays() {
+  killDisplay.textContent = `Enemies defeated: ${killCount}`;
+  heroHpDisplay.textContent = `HP: ${heroStats.hp}`;
+}
+
+let currentEnemy = null;
+
+// Configuration for enemy spawning
+const ENEMIES_PER_STAGE = 10; // Change to set how many foes share the same level
+const SUBLEVELS_PER_WORLD = 3; // Produces level strings like 1.1, 1.2...
+
+function getLevelInfo(count) {
+  const stage = Math.floor(count / ENEMIES_PER_STAGE);
+  const world = Math.floor(stage / SUBLEVELS_PER_WORLD) + 1;
+  const sub = (stage % SUBLEVELS_PER_WORLD) + 1;
+  const level = `${world}.${sub}`;
+  const hp = (stage + 1) * 10;
+  return { level, hp };
+}
+
+function spawnEnemy() {
+  if (currentEnemy) return;
+  const enemyEl = document.createElement('img');
+  const { level, hp } = getLevelInfo(killCount);
+  enemyEl.src = `assets/enemy${level}.png`;
+  enemyEl.className = 'enemy';
+  enemyEl.style.left = gameArea.offsetWidth + 'px';
+  gameArea.appendChild(enemyEl);
+
+  const enemy = { element: enemyEl, hp, attack: 1 };
+  currentEnemy = enemy;
+
+  let position = gameArea.offsetWidth;
+  const speed = 2 + Math.random() * 2;
+
+  function move() {
+    if (currentEnemy !== enemy) return;
+    position -= speed;
+    enemyEl.style.left = position + 'px';
+
+    if (position < hero.offsetLeft + hero.offsetWidth) {
+      enemyEl.style.left = hero.offsetLeft + hero.offsetWidth + 'px';
+      startCombat(enemy);
+      return;
+    }
+    requestAnimationFrame(move);
+  }
+  requestAnimationFrame(move);
+}
+
+function startCombat(enemy) {
+  const interval = setInterval(() => {
+    enemy.hp -= heroStats.attack;
+    heroStats.hp -= enemy.attack;
+    updateDisplays();
+
+    if (heroStats.hp <= 0) {
+      clearInterval(interval);
+      alert('Game Over');
+      return;
+    }
+    if (enemy.hp <= 0) {
+      clearInterval(interval);
+      enemy.element.remove();
+      killCount++;
+      currentEnemy = null;
+      updateDisplays();
+      spawnEnemy();
+    }
+  }, 1000);
+}
+
+updateDisplays();
+spawnEnemy();
+
+// Character menu logic
+const characterBtn = document.getElementById('characterBtn');
+const characterMenu = document.getElementById('characterMenu');
+const closeCharacter = document.getElementById('closeCharacter');
+
+characterBtn.addEventListener('click', () => {
+  characterMenu.classList.add('visible');
+});
+
+closeCharacter.addEventListener('click', () => {
+  characterMenu.classList.remove('visible');
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "idle-mushrooms-prototype",
+  "version": "0.1.0",
+  "description": "Simple idle game prototype",
+  "scripts": {
+    "test": "echo 'No tests yet'"
+  }
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,77 @@
+body {
+  margin: 0;
+  background: #222;
+  color: #fff;
+  font-family: Arial, sans-serif;
+}
+
+#ui {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 10;
+}
+
+#ui div {
+  margin-top: 4px;
+}
+
+#game {
+  position: relative;
+  width: 800px;
+  height: 300px;
+  margin: 60px auto;
+  background: #444;
+  overflow: hidden;
+}
+
+#hero,
+.enemy {
+  width: 80px;
+  height: 80px;
+  object-fit: contain;
+}
+
+#hero {
+  position: absolute;
+  bottom: 0;
+  left: 50px;
+}
+
+.enemy {
+  position: absolute;
+  bottom: 0;
+}
+
+#characterMenu {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: #333;
+  border: 2px solid #555;
+  padding: 20px;
+  display: none;
+}
+
+#characterMenu.visible {
+  display: block;
+}
+
+.slot {
+  margin: 10px 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.slot img {
+  width: 64px;
+  height: 64px;
+  border: 1px solid #555;
+}
+
+button {
+  padding: 6px 12px;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- display hero HP and add equipment menu with weapon slot
- add sword granting 2 damage and sequential enemy spawning with HP scaling
- implement basic combat loop with hero/enemy attack stats
- switch to PNG sprites and resize graphics
- vary enemy art by level using names like enemy1.1.png with configurable spawn counts
- remove placeholder PNG assets so repo contains no binaries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfe7f9b688832eafa60064b4eb0cac